### PR TITLE
Fix /usr/bin/time invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,24 +6,24 @@ export TZ := ":Asia/Kolkata"
 busy-python:
 	echo
 	echo "$$(date)" "[PYTHON] busy_loop.py (100_000_000) iterations"
-	/usr/bin/time python3 busy_loop.py
+	time python3 busy_loop.py;
 
 busy-pypy:
 	echo
 	echo "$$(date)" "[PYPY] busy_loop.py (100_000_000) iterations"
-	/usr/bin/time pypy3 busy_loop.py
+	time pypy3 busy_loop.py;
 
 busy-rust:
 	cargo build --release --quiet --bin busy
 	echo
 	echo "$$(date)" "[RUST] busy.rs (100_000_000) iterations"
-	/usr/bin/time ./target/release/busy
+	time ./target/release/busy;
 
 busy-rust-thread:
 	cargo build --release --quiet --bin threaded_busy
 	echo
 	echo "$$(date)" "[RUST] threaded_busy.rs (100_000_000) iterations"
-	/usr/bin/time ./target/release/threaded_busy
+	time ./target/release/threaded_busy;
 
 busy-py-all: busy-python busy-pypy
 

--- a/bench.sh
+++ b/bench.sh
@@ -1,10 +1,11 @@
+#!/bin/sh
 # runs each of the scripts one after another, prints the measurements to stdout
 export TZ=":Asia/Kolkata"
 
 # benching naive version
 rm -rf naive.db naive.db-shm naive.db-wal
 echo "$(date)" "[PYTHON] running naive.py (10_000_000) inserts"
-/usr/bin/time python3 naive.py
+time python3 naive.py
 # lets verify the data exists
 if [[ $(sqlite3 naive.db  "select count(*) from user";) != 10000000 ]]; then
   echo "data verification failed"
@@ -14,7 +15,7 @@ fi
 rm -rf naive_batched.db naive_batched.db-shm naive_batched.db-wal
 echo
 echo "$(date)" "[PYTHON] running naive_batched.py (10_000_000) inserts"
-/usr/bin/time python3 naive_batched.py
+time python3 naive_batched.py
 if [[ $(sqlite3 naive_batched.db  "select count(*) from user";) != 10000000 ]]; then
   echo "data verification failed"
 fi
@@ -23,7 +24,7 @@ fi
 rm -rf sqlite3_opt.db sqlite3_opt.db-shm sqlite3_opt.db-wal
 echo
 echo "$(date)" "[PYTHON] running sqlite3_opt.py (100_000_000) inserts"
-/usr/bin/time python3 sqlite3_opt.py
+time python3 sqlite3_opt.py
 if [[ $(sqlite3 sqlite3_opt.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
 fi
@@ -32,7 +33,7 @@ fi
 rm -rf sqlite3_opt.db sqlite3_opt.db-shm sqlite3_opt.db-wal
 echo
 echo "$(date)" "[PYPY] running sqlite3_opt.py (100_000_000) inserts"
-/usr/bin/time pypy3 sqlite3_opt.py
+time pypy3 sqlite3_opt.py
 if [[ $(sqlite3 sqlite3_opt.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
 fi
@@ -41,7 +42,7 @@ fi
 rm -rf sqlite3_opt_batched.db sqlite3_opt_batched.db-shm sqlite3_opt_batched.db-wal
 echo
 echo "$(date)" "[PYTHON] running sqlite3_opt_batched.py (100_000_000) inserts"
-/usr/bin/time python3 sqlite3_opt_batched.py
+time python3 sqlite3_opt_batched.py
 if [[ $(sqlite3 sqlite3_opt_batched.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
 fi
@@ -50,7 +51,7 @@ fi
 rm -rf threaded_batched.db threaded_batched.db-shm threaded_batched.db-wal
 echo
 echo "$(date)" "[PYTHON] running threaded_batched.py (100_000_000) inserts"
-/usr/bin/time python3 threaded_batched.py
+time python3 threaded_batched.py
 # this will fail anyways
 if [[ $(sqlite3 threaded_batched.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
@@ -60,7 +61,7 @@ fi
 rm -rf sqlite3_opt_batched.db sqlite3_opt_batched.db-shm sqlite3_opt_batched.db-wal
 echo
 echo "$(date)" "[PYPY] running sqlite3_opt_batched.py (100_000_000) inserts"
-/usr/bin/time pypy3 sqlite3_opt_batched.py
+time pypy3 sqlite3_opt_batched.py
 if [[ $(sqlite3 sqlite3_opt_batched.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
 fi
@@ -69,7 +70,7 @@ fi
 rm -rf threaded_batched.db threaded_batched.db-shm threaded_batched.db-wal
 echo
 echo "$(date)" "[PYPY] running threaded_batched.py (100_000_000) inserts"
-/usr/bin/time pypy3 threaded_batched.py
+time pypy3 threaded_batched.py
 # this will fail anyways
 if [[ $(sqlite3 threaded_batched.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
@@ -79,26 +80,26 @@ fi
 rm -rf basic_async.db basic_async.db-shm basic_async.db-wal
 cargo build --release --quiet --bin basic_async
 echo "$(date)" "[RUST] basic_async.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/basic_async
+time ./target/release/basic_async
 
 # benching with all prev sqlite optimisations, but on rust with rusqlite
 rm -rf basic.db basic.db-shm basic.db-wal
 cargo build --release --quiet --bin basic
 echo "$(date)" "[RUST] basic.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/basic
+time ./target/release/basic
 
 # benching with all prev sqlite optimisations, but on rust with rusqlite with batched inserts where
 # each batch is a really large ass string
 rm -rf basic_batched_wp.db basic_batched_wp.db-shm basic_batched_wp.db-wal
 cargo build --release --quiet --bin basic_batched_wp
 echo "$(date)" "[RUST] basic_batched_wp.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/basic_batched_wp
+time ./target/release/basic_batched_wp
 
 # just like the previous version, so really bad.
 rm -rf threaded_str_batched.db threaded_str_batched.db-shm threaded_str_batched.db-wal
 cargo build --release --quiet --bin threaded_str_batched
 echo "$(date)" "[RUST] threaded_str_batched.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/threaded_str_batched
+time ./target/release/threaded_str_batched
 
 
 # benching with all prev sqlite optimisations, but on rust with rusqlite with inserts where
@@ -106,17 +107,17 @@ echo "$(date)" "[RUST] threaded_str_batched.rs (100_000_000) inserts"
 rm -rf basic_prep.db basic_prep.db-shm basic_prep.db-wal
 cargo build --release --quiet --bin basic_prep
 echo "$(date)" "[RUST] basic_prep.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/basic_prep
+time ./target/release/basic_prep
 
 # benching with all prev sqlite optimisations, but on rust with rusqlite with batched inserts where
 # each batch is a proper prepared statement
 rm -rf basic_batched.db basic_batched.db-shm basic_batched.db-wal
 cargo build --release --quiet --bin basic_batched
 echo "$(date)" "[RUST] basic_batched.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/basic_batched
+time ./target/release/basic_batched
 
 # previous version but threaded
 rm -rf threaded_batched.db threaded_batched.db-shm threaded_batched.db-wal
 cargo build --release --quiet --bin threaded_batched
 echo "$(date)" "[RUST] threaded_batched.rs (100_000_000) inserts"
-/usr/bin/time ./target/release/threaded_batched
+time ./target/release/threaded_batched


### PR DESCRIPTION
`/usr/bin/time` doesn't exist on many systems
because it is implemented as a shell-builtin.

Putting a semi-colon at the end of the command forces
make to run a shell for the same, and invokes the correct
time.

Added a shebang for `bench.sh` so hopefully that should also work everywhere?

Ref: https://stackoverflow.com/a/17550243/368328