### PR TITLE
Speed up the commons functions

### DIFF
--- a/commons.py
+++ b/commons.py
@@ -19,6 +19,8 @@ def create_table(con: sqlite3.Connection):
 def get_random_area_code() -> str:
     return str(random.randint(100000, 999999))
 
+# Slightly faster. The doc for random.sample mentions:
+# To choose a sample from a range of integers, use a range() object as an argument. This is especially fast and space efficient for sampling from a large population: sample(range(10000000), k=60).
 def get_random_age() -> int:
     return random.choice(range(5,16,5))
 

--- a/commons.py
+++ b/commons.py
@@ -17,16 +17,13 @@ def create_table(con: sqlite3.Connection):
 
 
 def get_random_area_code() -> str:
-    return ''.join([F"{random.randint(0, 9)}" for _ in range(0, 6)])
-
+    return str(random.randint(100000, 999999))
 
 def get_random_age() -> int:
-    return random.choice([5, 10, 15])
-
+    return random.choice(range(5,16,5))
 
 def get_random_active() -> int:
-    return 1 if get_random_bool() else 0
-
+    return random.getrandbits(1)
 
 def get_random_bool() -> bool:
     return bool(random.getrandbits(1))


### PR DESCRIPTION
My 10M (sqlite3_opt_batched) run goes from 42s to 26s.

Switching to https://docs.python.org/3/library/os.html#os.urandom would
make this even faster, but I don't think that's the point of the
exercise so leaving it at this. I think it's still nice to have because
it reduces the time by a lot and makes it _faster for me to benchmark_

result for `threaded_batched.py` against `pypy3` on my i7 for all 100M records:

`real 111.251	user 104.187	sys 4.483	pcpu 97.68`

I seem to be running out of memory though (process keeps getting OOM-killed, wondering if that can be fixed somehow).