### PR TITLE
Increase the page size to 64K

### DIFF
--- a/src/bin/threaded_batched.rs
+++ b/src/bin/threaded_batched.rs
@@ -29,7 +29,8 @@ fn consumer(rx: Receiver<ParamValues>) {
               PRAGMA synchronous = 0;
               PRAGMA cache_size = 1000000;
               PRAGMA locking_mode = EXCLUSIVE;
-              PRAGMA temp_store = MEMORY;",
+              PRAGMA temp_store = MEMORY;
+              PRAGMA page_size = 65536;",
     )
     .expect("PRAGMA");
     conn.execute(


### PR DESCRIPTION
https://avi.im/blag/2021/fast-sqlite-inserts/ mentions that even a fully in-memory db takes ~29 seconds to insert 100M rows. Increasing the size of btree nodes, from 4 KB to 64 KB, seems like the next low-hanging fruit to try.

Unfortunately, this change also impacts the cache size: it is specified in pages, so increasing the page size from 4 KB to 64 KB also grows the cache by 16x. Any speed-up from this commit should therefore be compared with a version that sets `PRAGMA cache_size = 16000000;`.