### PR TITLE
Avoid the slow Display::fmt trait for area code generation

### DIFF
--- a/src/bin/common.rs
+++ b/src/bin/common.rs
@@ -14,5 +14,5 @@ pub fn get_random_bool() -> bool {
 }
 
 pub fn get_random_area_code() -> String {
-    format!("{:06}", fastrand::u32(0..999_999))
+    fastrand::u32(100_000..999_999).to_string()
 }


### PR DESCRIPTION
As described in the other PR #12 I discovered the "slow" Display::fmt being called for formatting the area code using `perf`.

This PR does limit the generated area code to numbers above 100_000 where before it could be less, thus losing some randomness, but it's about the same "trick" as used in #2  for the python side.