### PR TITLE
Add pure SQLite approach, with generate_series

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -5,7 +5,7 @@ export TZ=":Asia/Kolkata"
 # benching sqlite cli
 rm -rf sqlite3.db
 echo "$(date)" "[SQLite] running sqlite3 (100_000_000) inserts"
-time sqlite3 sqlite3.db '.read schema.sql' '.read load.sql'
+time sqlite3 sqlite3.db '.read load.sql'
 if [[ $(sqlite3 sqlite3.db  "select count(*) from user";) != 100000000 ]]; then
   echo "data verification failed"
 fi

--- a/bench.sh
+++ b/bench.sh
@@ -2,6 +2,14 @@
 # runs each of the scripts one after another, prints the measurements to stdout
 export TZ=":Asia/Kolkata"
 
+# benching sqlite cli
+rm -rf sqlite3.db
+echo "$(date)" "[SQLite] running sqlite3 (100_000_000) inserts"
+time sqlite3 sqlite3.db '.read schema.sql' '.read load.sql'
+if [[ $(sqlite3 sqlite3.db  "select count(*) from user";) != 100000000 ]]; then
+  echo "data verification failed"
+fi
+
 # benching naive version
 rm -rf naive.db naive.db-shm naive.db-wal
 echo "$(date)" "[PYTHON] running naive.py (10_000_000) inserts"

--- a/load.sql
+++ b/load.sql
@@ -1,0 +1,13 @@
+create table IF NOT EXISTS user (
+  id INTEGER not null primary key,
+  area CHAR(6),
+  age INTEGER not null,
+  active INTEGER not null
+);
+
+insert into user (area, age, active)
+select 
+  abs(random() % 99999) as area, 
+  (abs(random() % 3) + 1) * 5 as age, 
+  abs(random() % 1) as active
+from generate_series(1, 100000000);


### PR DESCRIPTION
Based from #11. This PR adds a new method of quickly inserting 100M rows into a SQLite table, using a pure SQLite approach.

Using the [`generate_series`](https://www.sqlite.org/series.html) table valued function, we can insert 100M rows into a table very, very quickly with a single `INSERT INTO ... SELECT` statement.

The question of "how fast is this" is difficult to answer. I'm not sure if it's something with my computer/background apps I'm running, but my benchmarks of the previous python/rust solutions have been all over the place. Using this approach, I get `57s`.  For the pypy threaded_batched approach, I get `5m50s`, and with the rust threaded_batched approach, I get `1m9s`. 

```
$ time sqlite3x sqlite3.db  '.read load.sql'
real 0m57.414s
user 0m45.714s
sys 0m6.574s

$ time ~/Downloads/pypy3.8-v7.3.7-osx64/bin/pypy3 threaded_batched.py
real 5m49.887s
user 3m4.141s
sys 1m52.690s

$ time ./target/release/threaded_batched
real 1m9.807s
user 0m49.430s
sys 0m29.562s
```

Given this, I'm tempted to say that this actually might be the fastest solution, but given my wildly different benchmark times (pypy's `5m50s` vs `126s`, rust's `1m9s vs 30s`), I'd love to see how this runs on your computer, using the full benchmark! 

## Why (I think) it's so fast

One solid reason why I think this approach is so fast is because it's only a single SQL statement that is being ran. All the other approaches are performing millions of `insert into ... values (...)` SQL statements at a time, which is a fast operation, but doing anything millions of times starts to add up. We see an obvious benefit when we start to batch statements together, but even batching 50 at a time is still 2 million distinct SQL statements that need to be ran.

Also, by using `generate_series`, all operations are kept in C, which is very fast. Rust and pypy are also fast, but my guess is that context switching between Rust -> C or pypy -> C takes a non-trivial amount of time that adds up fast. 

Also, on `generate_series` vs recursive CTEs, the [`generate_series` page](https://www.sqlite.org/series.html#equivalent_recursive_common_table_expression) mentions that recursive CTEs are slower than table-valued functions.

Note: `generate_series` may not be in your sqlite CLI by default, so make sure the `sqlite3` CLI that you have contains that 

Would love to hear what you think, and to see the "official" benchmark numbers!